### PR TITLE
Fix code scanning alert no. 18: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -2174,7 +2174,7 @@ if (typeof jQuery === 'undefined') {
   var Affix = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
-    this.$target = $(this.options.target)
+    this.$target = $.find(this.options.target)
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/18](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/18)

To fix the problem, we need to ensure that the `target` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `target` option to the jQuery selector. This change will prevent the evaluation of the `target` option as HTML.

- Modify the `Affix` constructor to use `jQuery.find` for the `target` option.
- Ensure that the `target` option is always interpreted as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
