### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -108,7 +108,7 @@ if (typeof jQuery === 'undefined') {
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = $(selector)
+    var $parent = $.find(selector)
 
     if (e) e.preventDefault()
 


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/3](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/3)

To fix the problem, we need to ensure that the `selector` variable is properly sanitized before it is used in a jQuery selector. One way to achieve this is by using the `$.find` method, which interprets the input strictly as a CSS selector and not as HTML. This prevents the execution of arbitrary JavaScript.

- Replace the direct use of `$(selector)` with `$.find(selector)` to ensure that the input is treated as a CSS selector.
- Ensure that the `selector` variable is properly sanitized before it is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
