### PR TITLE
Fix code scanning alert no. 11: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -546,7 +546,7 @@ if (typeof jQuery === 'undefined') {
   var Collapse = function (element, options) {
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
-    this.$trigger      = $(this.options.trigger).filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
+    this.$trigger      = $(document).find(this.options.trigger).filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
     this.transitioning = null
 
     if (this.options.parent) {


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/11](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/11)

To fix the problem, we need to ensure that the `trigger` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `trigger` option to the jQuery selector. This change will prevent the evaluation of the `trigger` option as HTML.

- Modify the `Collapse` constructor to use `jQuery.find` for the `trigger` option.
- Ensure that the `trigger` option is always interpreted as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
