### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -500,7 +500,8 @@ if (typeof jQuery === 'undefined') {
   var clickHandler = function (e) {
     var href
     var $this   = $(this)
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var targetSelector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, ''); // strip for ie7
+    var $target = $(document.querySelector(targetSelector));
     if (!$target.hasClass('carousel')) return
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/4](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/4)

To fix the problem, we should avoid using the `$` function with untrusted input directly. Instead, we can use a safer method to select the target element. One approach is to use `document.querySelector` or `$.find` to ensure that the input is treated strictly as a CSS selector and not as HTML.

We will replace the line that uses `$($this.attr('data-target'))` with a safer alternative. Specifically, we will use `document.querySelector` to select the target element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
