### PR TITLE
Fix code scanning alert no. 12: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -667,8 +667,12 @@ if (typeof jQuery === 'undefined') {
   }
 
   Collapse.prototype.getParent = function () {
-    return $(this.options.parent)
-      .find('[data-toggle="collapse"][data-parent="' + this.options.parent + '"]')
+    var parent = this.options.parent;
+    if (typeof parent !== 'string' || !parent.trim().length) {
+      throw new Error('Invalid parent selector');
+    }
+    return $.find(parent)
+      .find('[data-toggle="collapse"][data-parent="' + parent + '"]')
       .each($.proxy(function (i, element) {
         var $element = $(element)
         this.addAriaAndCollapsedClass(getTargetFromTrigger($element), $element)


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/12](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/12)

To fix the problem, we need to ensure that the `this.options.parent` value is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery` to interpret the selector safely. Additionally, we should validate the `parent` option to ensure it is a valid CSS selector.

- Replace the use of `$(this.options.parent)` with `$.find(this.options.parent)` to ensure it is always treated as a CSS selector.
- Validate the `parent` option to ensure it is a valid CSS selector before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
