### PR TITLE
Fix code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -1284,7 +1284,7 @@ if (typeof jQuery === 'undefined') {
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-    this.$viewport = this.options.viewport && $(this.options.viewport.selector || this.options.viewport)
+    this.$viewport = this.options.viewport && $.find(this.options.viewport.selector || this.options.viewport)
 
     var triggers = this.options.trigger.split(' ')
 


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/13](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/13)

To fix the problem, we need to ensure that the `viewport.selector` is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of directly using `jQuery` to interpret the selector. This change will prevent the selector from being interpreted as HTML, thus mitigating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
