### PR TITLE
Fix code scanning alert no. 17: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -1946,7 +1946,7 @@ if (typeof jQuery === 'undefined') {
         '[data-target="' + target + '"],' +
         this.selector + '[href="' + target + '"]'
 
-    var active = $(selector)
+    var active = $.find(selector)
       .parents('li')
       .addClass('active')
 
@@ -1960,7 +1960,7 @@ if (typeof jQuery === 'undefined') {
   }
 
   ScrollSpy.prototype.clear = function () {
-    $(this.selector)
+    $.find(this.selector)
       .parentsUntil(this.options.target, '.active')
       .removeClass('active')
   }


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/17](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/17)

To fix the problem, we need to ensure that the `this.selector` variable is always treated as a CSS selector and not as HTML. This can be achieved by using jQuery's `find` method instead of directly using the selector in jQuery. This method ensures that the input is always interpreted as a CSS selector.

- Modify the `ScrollSpy.prototype.clear` and `ScrollSpy.prototype.activate` methods to use `jQuery.find` for constructing the selectors.
- Ensure that the `this.selector` is always treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
