### PR TITLE
Fix code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -1216,7 +1216,8 @@ if (typeof jQuery === 'undefined') {
   $(document).on('click.bs.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this   = $(this)
     var href    = $this.attr('href')
-    var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) // strip for ie7
+    var targetSelector = $this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var $target = $(document).find(targetSelector)
     var option  = $target.data('bs.modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
     if ($this.is('a')) e.preventDefault()


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/7](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/7)

To fix the problem, we need to ensure that the value of the `data-target` attribute is treated as a CSS selector and not as HTML. This can be achieved by using the `$.find` method instead of `$`. The `$.find` method will interpret the value strictly as a CSS selector, preventing any potential XSS attacks.

- Replace the use of `$($this.attr('data-target'))` with `$.find($this.attr('data-target'))`.
- Ensure that the `$.find` method is used in a way that maintains the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
