### PR TITLE
Fix code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/assets/js/vendor/bootstrap.js
+++ b/assets/js/vendor/bootstrap.js
@@ -1415,7 +1415,7 @@ if (typeof jQuery === 'undefined') {
         .addClass(placement)
         .data('bs.' + this.type, this)
 
-      this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+      this.options.container ? $tip.appendTo($.find(this.options.container)) : $tip.insertAfter(this.$element)
 
       var pos          = this.getPosition()
       var actualWidth  = $tip[0].offsetWidth
@@ -1423,7 +1423,7 @@ if (typeof jQuery === 'undefined') {
 
       if (autoPlace) {
         var orgPlacement = placement
-        var $container   = this.options.container ? $(this.options.container) : this.$element.parent()
+        var $container   = this.options.container ? $.find(this.options.container) : this.$element.parent()
         var containerDim = this.getPosition($container)
 
         placement = placement == 'bottom' && pos.bottom + actualHeight > containerDim.bottom ? 'top'    :


### PR DESCRIPTION
Fixes [https://github.com/rohan-ngm/rrl-securities/security/code-scanning/15](https://github.com/rohan-ngm/rrl-securities/security/code-scanning/15)

To fix the problem, we need to ensure that the `container` option is always treated as a CSS selector or a DOM element and not as raw HTML. This can be achieved by validating the `container` option before using it in jQuery's `appendTo` method. We can use jQuery's `find` method to ensure that the `container` is interpreted as a CSS selector.

- Modify the `Tooltip.prototype.show` method to validate the `container` option.
- Use jQuery's `find` method to ensure the `container` is treated as a CSS selector.
- Update the relevant lines in the `assets/js/vendor/bootstrap.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
